### PR TITLE
add platform-specific dependencies to the gem

### DIFF
--- a/ext/run_in_background/mkrf_conf.rb
+++ b/ext/run_in_background/mkrf_conf.rb
@@ -1,4 +1,4 @@
-# this extension used to install platform specific gem dependencies
+# This extension used to install platform specific gem dependencies
 # for more information:
 #     http://stackoverflow.com/questions/4596606/rubygems-how-do-i-add-platform-specific-dependency/10249133#10249133
 #     https://github.com/openshift/os-client-tools/blob/master/express/ext/mkrf_conf.rb

--- a/ext/run_in_background/mkrf_conf.rb
+++ b/ext/run_in_background/mkrf_conf.rb
@@ -1,0 +1,34 @@
+# this extension used to install platform specific gem dependencies
+# for more information:
+#     http://stackoverflow.com/questions/4596606/rubygems-how-do-i-add-platform-specific-dependency/10249133#10249133
+#     https://github.com/openshift/os-client-tools/blob/master/express/ext/mkrf_conf.rb
+
+require 'rubygems'
+require 'rubygems/command.rb'
+require 'rubygems/dependency_installer.rb'
+#begin
+#Gem::Command.build_args = ARGV
+#rescue NoMethodError
+#end
+inst = Gem::DependencyInstaller.new
+begin
+  if Gem::win_platform?
+    if Gem::Specification.find_all_by_name('sys-uname').empty?
+      inst.install 'sys-uname'
+    end
+    if Gem::Specification.find_all_by_name('win32-service').empty?
+      inst.install 'win32-service'
+    end
+  else
+    if Gem::Specification.find_all_by_name('daemons').empty?
+      inst.install 'daemons'
+    end
+  end
+rescue Exception => e
+  puts e.to_s
+  exit(1)
+end
+
+f = File.open(File.join(File.dirname(__FILE__), "Rakefile"), "w")   # create dummy rakefile to indicate success
+f.write("task :default\n")
+f.close

--- a/run_in_background.gemspec
+++ b/run_in_background.gemspec
@@ -15,9 +15,10 @@ Gem::Specification.new do |s|
   s.test_files  = Dir['test/run_in_background/**/*'] & `git ls-files -z`.split("\0")
   s.add_dependency('log')
   s.add_dependency('params')
-  s.add_dependency('daemons')
-  s.add_dependency('win32-service')
-  s.add_dependency('sys-uname')
-  # Shouldn't be run from comman line
-  # #s.executables << 'run_in_background/daemon_wrapper'  
+#  Add platform dependant gems via extension
+#    Linux dependencies: daemons
+#    Windows dependencies: win32-service, sys-uname
+  s.extensions = ['ext/run_in_background/mkrf_conf.rb']
+  # Shouldn't be run from comman line, thus commented
+  # s.executables << 'run_in_background/daemon_wrapper'  
 end


### PR DESCRIPTION
Fix for the platform-specific gem dependencies.
It fix the following problem that appears when installing content_server from gem on Linux:
Fetching: win32-api-1.4.8.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing content_server:
        ERROR: Failed to build gem native extension.
