### PR TITLE
Issue215 ruby noexec wrapper fix

### DIFF
--- a/lib/params.rb
+++ b/lib/params.rb
@@ -253,8 +253,8 @@ module Params
   # Precedence is: Defined params, file and command line is highest.
   def Params.init(args)
     #define default configuration file
-    Params['conf_file'] = "~/.bbfs/etc/config_#{executable_name}.yml"
-    
+    Params['conf_file'] = "~/.bbfs/etc/config_#{File.basename($PROGRAM_NAME)}.yml"
+
     @init_info_messages = []
     @init_warning_messages = []
 
@@ -403,17 +403,11 @@ paths:
     }
   end
 
-  #Auxiliary method to retrieve the executable name
-  def Params.executable_name
-    /([a-zA-Z0-9\-_\.]+):\d+/ =~ caller[caller.size-1]
-    return $1
-  end
-  
   Params.path('conf_file', nil, 'Configuration file path.')
   Params.boolean('print_params_to_stdout', false, 'print_params_to_stdout or not during Params.init')
 
   private_class_method :parse_command_line_arguments, \
                        :raise_error_if_param_exists, :raise_error_if_param_does_not_exist, \
-                       :read_yml_params, :override_param, :executable_name
+                       :read_yml_params, :override_param
 end
 


### PR DESCRIPTION
[issue215](https://github.com/bbfsdev/bbfs/issues/215)

Validation:

```
[genadyp@lnx-genadyp bbfs]$ rm ~/.bbfs/log/*
[genadyp@lnx-genadyp bbfs]$ ruby -Ilib bin/content_server 
^C
Interrupt or Exit happened in server:'content_server'.
Exception type:'Interrupt'.
Exception message:''.
Stopping process.
Force writing local content data to /home/genadyp/.bbfs/var/content.data.
...
[genadyp@lnx-genadyp bbfs]$ grep conf_file /home/genadyp/.bbfs/log/content_server000001.log
[INFO] [2013-08-19 18:40:54] [log.rb:116:Param #1: conf_file=/home/genadyp/.bbfs/etc/config_content_server.yml]

[genadyp@lnx-genadyp bbfs]$ 
[genadyp@lnx-genadyp bbfs]$ cd
[genadyp@lnx-genadyp ~]$ rm ~/.bbfs/log/*
[genadyp@lnx-genadyp ~]$ backup_server 
Interrupt or Exit happened in server:'backup_server'.
Exception type:'Interrupt'.
Exception message:''.
Stopping process.
...
[genadyp@lnx-genadyp ~]$ grep conf_file /home/genadyp/.bbfs/log/backup_server000001.log4r 
[INFO] [2013-08-19 18:41:42] [log.rb:116:Param #1: conf_file=/home/genadyp/.bbfs/etc/config_backup_server.yml]
```
