### PR TITLE
Issue 237 monitor dir rename

### DIFF
--- a/lib/content_data/content_data.rb
+++ b/lib/content_data/content_data.rb
@@ -442,7 +442,7 @@ module ContentData
         instances_enum = instances.each_key
         loop {
           location = instances_enum.next rescue break
-          instance_mod_time,_ = instances[location]
+          instance_mod_time = instances[location][0]
           if instance_mod_time < min_time_per_checksum
             min_time_per_checksum = instance_mod_time
           end
@@ -502,7 +502,7 @@ module ContentData
         instances_enum = instances[1].each_key
         loop {
           unique_path = instances_enum.next rescue break
-          instance_mtime = instances[1][unique_path]
+          instance_mtime = instances[1][unique_path][0]
           instance_info = [checksum, content_mtime, content_size, instance_mtime]
           instance_info.concat(unique_path)
           unless check_instance(instance_info)

--- a/lib/content_data/content_data.rb
+++ b/lib/content_data/content_data.rb
@@ -71,6 +71,9 @@ module ContentData
         loop {
           location =  instances_db_enum.next rescue break
           inst_mod_times = instances_db[location]
+          # we use deep clone for location since map key is using shallow clone.
+          # we dont want references between new content data
+          # and orig object. This will help the GC dispose the orig object if not used any more.
           instances_db_cloned[[location[0].clone,location[1].clone]] = inst_mod_times
         }
         clone_contents_info[checksum] = [size,
@@ -95,7 +98,7 @@ module ContentData
     # iterator over @contents_info data structure (including instances)
     # block is provided with: checksum, size, content modification time,
     #   instance modification time, server and file path
-    def each_instance_with_index_time(&block)
+    def each_instance(&block)
       contents_enum = @contents_info.each_key
       loop {
         checksum = contents_enum.next rescue break
@@ -108,26 +111,6 @@ module ContentData
           inst_mod_time, inst_index_time = content_info[1][location]
           block.call(checksum,content_info[0], content_info[2], inst_mod_time,
                      location[0], location[1], inst_index_time)
-        }
-      }
-    end
-
-    # iterator over @contents_info data structure (including instances)
-    # block is provided with: checksum, size, content modification time,
-    #   instance modification time, server and file path
-    def each_instance(&block)
-      contents_enum = @contents_info.each_key
-      loop {
-        checksum = contents_enum.next rescue break
-        content_info = @contents_info[checksum]
-        content_info_enum = content_info[1].each_key
-        loop {
-          location = content_info_enum.next rescue break
-          # provide the block with: checksum, size, content modification time,instance modification time,
-          #   server and path.
-          inst_mod_time,_ = content_info[1][location]
-          block.call(checksum,content_info[0], content_info[2], inst_mod_time,
-                     location[0], location[1])
         }
       }
     end

--- a/lib/content_data/content_data.rb
+++ b/lib/content_data/content_data.rb
@@ -23,7 +23,7 @@ module ContentData
   #   unify time, add/remove instance, queries, merge, remove directory and more.
   # Content info data structure:
   #   @contents_info = { Checksum -> [size, *instances*, content_modification_time] }
-  #     *instances* = {[server,path] -> instance_modification_time }
+  #     *instances* = {[server,path] -> [instance_modification_time,index_time] }
   # Notes:
   #   1. content_modification_time is the instance_modification_time of the first
   #      instances which was added to @contents_info
@@ -70,8 +70,8 @@ module ContentData
         instances_db_enum = instances_db.each_key
         loop {
           location =  instances_db_enum.next rescue break
-          instance_mtime = instances_db[location]
-          instances_db_cloned[[location[0].clone,location[1].clone]]=instance_mtime
+          inst_mod_times = instances_db[location]
+          instances_db_cloned[[location[0].clone,location[1].clone]] = inst_mod_times
         }
         clone_contents_info[checksum] = [size,
                               instances_db_cloned,
@@ -95,6 +95,26 @@ module ContentData
     # iterator over @contents_info data structure (including instances)
     # block is provided with: checksum, size, content modification time,
     #   instance modification time, server and file path
+    def each_instance_with_index_time(&block)
+      contents_enum = @contents_info.each_key
+      loop {
+        checksum = contents_enum.next rescue break
+        content_info = @contents_info[checksum]
+        content_info_enum = content_info[1].each_key
+        loop {
+          location = content_info_enum.next rescue break
+          # provide the block with: checksum, size, content modification time,instance modification time,
+          #   server and path.
+          inst_mod_time, inst_index_time = content_info[1][location]
+          block.call(checksum,content_info[0], content_info[2], inst_mod_time,
+                     location[0], location[1], inst_index_time)
+        }
+      }
+    end
+
+    # iterator over @contents_info data structure (including instances)
+    # block is provided with: checksum, size, content modification time,
+    #   instance modification time, server and file path
     def each_instance(&block)
       contents_enum = @contents_info.each_key
       loop {
@@ -105,8 +125,8 @@ module ContentData
           location = content_info_enum.next rescue break
           # provide the block with: checksum, size, content modification time,instance modification time,
           #   server and path.
-          instance_modification_time = content_info[1][location]
-          block.call(checksum,content_info[0], content_info[2], instance_modification_time,
+          inst_mod_time,_ = content_info[1][location]
+          block.call(checksum,content_info[0], content_info[2], inst_mod_time,
                      location[0], location[1])
         }
       }
@@ -122,8 +142,8 @@ module ContentData
         location = instances_db_enum.next rescue break
         # provide the block with: checksum, size, content modification time,instance modification time,
         #   server and path.
-        instance_modification_time = content_info[1][location]
-        block.call(checksum,content_info[0], content_info[2], instance_modification_time,
+        inst_mod_time,_ = content_info[1][location]
+        block.call(checksum,content_info[0], content_info[2], inst_mod_time,
                    location[0], location[1])
       }
     end
@@ -146,10 +166,11 @@ module ContentData
       content_info = @contents_info[checksum]
       return nil if content_info.nil?
       instances = content_info[1]
-      instance_time = instances[location]
+      instance_time,_ = instances[location]
+      instance_time
     end
 
-    def add_instance(checksum, size, server, path, modification_time)
+    def add_instance(checksum, size, server, path, modification_time, index_time=Time.now.to_i)
       location = [server, path]
 
       # file was changed but remove_instance was not called
@@ -161,7 +182,7 @@ module ContentData
       content_info = @contents_info[checksum]
       if content_info.nil?
         @contents_info[checksum] = [size,
-                                    {location => modification_time},
+                                    {location => [modification_time,index_time]},
                                     modification_time]
       else
         if size != content_info[0]
@@ -172,7 +193,7 @@ module ContentData
         #override file if needed
         content_info[0] = size
         instances = content_info[1]
-        instances[location] = modification_time
+        instances[location] = [modification_time, index_time]
       end
       @instances_info[location] = checksum
     end
@@ -236,7 +257,7 @@ module ContentData
         local_instances =  local_content_info[1]
         return false if other.checksum_instances_size(checksum) != local_instances.length
         location = [server, path]
-        local_instance_mod_time = local_instances[location]
+        local_instance_mod_time, _ = local_instances[location]
         return false if local_instance_mod_time.nil?
         return false if local_instance_mod_time != instance_mod_time
       }
@@ -318,8 +339,9 @@ module ContentData
           location = instances_db_enum.next rescue break
           # provide the block with: checksum, size, content modification time,instance modification time,
           #   server and path.
-          instance_modification_time = content_info[1][location]
-          file.write("#{checksum},#{content_info[0]},#{location[0]},#{location[1]},#{instance_modification_time}\n")
+          instance_modification_time,instance_index_time = content_info[1][location]
+          file.write("#{checksum},#{content_info[0]},#{location[0]},#{location[1]}," +
+                     "#{instance_modification_time},#{instance_index_time}\n")
         }
         chunk_counter += 1
         break if chunk_counter == chunk_size
@@ -397,20 +419,21 @@ module ContentData
         return reset_load_from_file(filename, file, "Expected to read Instance line but reached EOF") unless instance_line
         parameters = instance_line.split(',')
         # bugfix: if file name consist a comma then parsing based on comma separating fails
-        if (parameters.size > 5)
-          (4..parameters.size-2).each do |i|
+        if (parameters.size > 6)
+          (4..parameters.size-3).each do |i|
             parameters[3] = [parameters[3], parameters[i]].join(",")
           end
-          (4..parameters.size-2).each do |i|
+          (4..parameters.size-3).each do |i|
             parameters.delete_at(4)
           end
         end
 
-        add_instance(parameters[0],
-                     parameters[1].to_i,
-                     parameters[2],
-                     parameters[3],
-                     parameters[4].to_i)
+        add_instance(parameters[0],        #checksum
+                     parameters[1].to_i,   # size
+                     parameters[2],        # server
+                     parameters[3],        # path
+                     parameters[4].to_i,   # mod time
+                     parameters[5].to_i)   # index time
         chunk_index += 1
       end
       true
@@ -436,7 +459,7 @@ module ContentData
         instances_enum = instances.each_key
         loop {
           location = instances_enum.next rescue break
-          instance_mod_time = instances[location]
+          instance_mod_time,_ = instances[location]
           if instance_mod_time < min_time_per_checksum
             min_time_per_checksum = instance_mod_time
           end
@@ -445,7 +468,7 @@ module ContentData
         instances_enum = instances.each_key
         loop {
           location = instances_enum.next rescue break
-          instances[location] = min_time_per_checksum
+          instances[location][0] = min_time_per_checksum
         }
         # update content time with min time
         content_info[2] = min_time_per_checksum

--- a/lib/content_data/content_data.rb
+++ b/lib/content_data/content_data.rb
@@ -74,7 +74,7 @@ module ContentData
           # we use deep clone for location since map key is using shallow clone.
           # we dont want references between new content data
           # and orig object. This will help the GC dispose the orig object if not used any more.
-          instances_db_cloned[[location[0].clone,location[1].clone]] = inst_mod_times
+          instances_db_cloned[[location[0].clone,location[1].clone]] = inst_mod_times.clone
         }
         clone_contents_info[checksum] = [size,
                               instances_db_cloned,

--- a/lib/content_server/server.rb
+++ b/lib/content_server/server.rb
@@ -32,6 +32,7 @@ module ContentServer
     $remote_content_data_lock = nil
     $remote_content_data = nil
     $last_content_data_id = nil
+    $file_attr_to_ref = {}
   end
 
   def handle_program_termination(exception)

--- a/lib/content_server/server.rb
+++ b/lib/content_server/server.rb
@@ -32,7 +32,7 @@ module ContentServer
     $remote_content_data_lock = nil
     $remote_content_data = nil
     $last_content_data_id = nil
-    $file_attr_to_ref = {}
+    $file_attr_to_checksum = {}  # used for monitor manual file changes feature
   end
 
   def handle_program_termination(exception)

--- a/lib/content_server/server.rb
+++ b/lib/content_server/server.rb
@@ -32,7 +32,6 @@ module ContentServer
     $remote_content_data_lock = nil
     $remote_content_data = nil
     $last_content_data_id = nil
-    $file_attr_to_checksum = {}  # used for monitor manual file changes feature
   end
 
   def handle_program_termination(exception)

--- a/lib/file_monitoring.rb
+++ b/lib/file_monitoring.rb
@@ -20,8 +20,8 @@ module FileMonitoring
               'This log containd track of changes found during monitoring')
   Params.complex('monitoring_paths', [], 'Array of Hashes with 3 fields: ' \
                  'path, scan_period and stable_state.')
-  Params.boolean('manual_file_changes', false, 'true, indicates to application to check if new files were copied ' \
-                 'or moved from other location. In this case content data file should be updated accordingly')
+  Params.boolean('manual_file_changes', false, 'true, indicates to application that a set of files were ' \
+    ' moved/copied we we should not index them but rather copy their hashes from contents there were copied from')
 
   # @see FileMonitoring#monitor_files
   def monitor_files

--- a/lib/file_monitoring.rb
+++ b/lib/file_monitoring.rb
@@ -20,6 +20,8 @@ module FileMonitoring
               'This log containd track of changes found during monitoring')
   Params.complex('monitoring_paths', [], 'Array of Hashes with 3 fields: ' \
                  'path, scan_period and stable_state.')
+  Params.boolean('manual_file_changes', false, 'true, indicates to application to check if new files were copied ' \
+                 'or moved from other location. In this case content data file should be updated accordingly')
 
   # @see FileMonitoring#monitor_files
   def monitor_files

--- a/lib/file_monitoring/file_monitoring.rb
+++ b/lib/file_monitoring/file_monitoring.rb
@@ -69,9 +69,11 @@ module FileMonitoring
             unless ident_file_info
               #  Add file checksum to map
               $file_attr_to_checksum[file_attr_str] = IdentFileInfo.new(checksum)
+              puts "Added file:#{file_attr_str} to map"
             else
               # File already in map. Need to mark as not unique
               ident_file_info.unique = false  # file will be skipped if found at new location
+              puts "File #{file_attr_str} already exists"
             end
           end
           # construct sub paths array from full file path:

--- a/lib/file_monitoring/file_monitoring.rb
+++ b/lib/file_monitoring/file_monitoring.rb
@@ -112,22 +112,24 @@ module FileMonitoring
           # -------------------------- MANUAL MODE
           # ------------ LOOP DIRS
           dir_stat_array.each { | dir_stat|
-            Log.info("In Manual mode. Start monitor path:%s. moved or copied files (same name, size and time " +
-                         "modification) will use the checksum of the original files and be updated in " +
-                         "content data file", dir_stat[0].path)
-            $testing_memory_log.info("Start monitor path:#{dir_stat[0].path} moved or copied files (same name, size and " +
-                                         "time modification) will use the checksum of the original files and be updated in " +
-                                         "content data file") if $testing_memory_active
+            log_msg = "In Manual mode. Start monitor path:%s. moved or copied files (same name, size and time " +
+                "modification) will use the checksum of the original files and be updated in " +
+                "content data file" % [dir_stat[0].path]
+            Log.info(log_msg)
+            $testing_memory_log.info(log_msg) if $testing_memory_active
+
             # ------- MONITOR
             dir_stat[0].monitor(file_attr_to_checksum)
 
             # ------- REMOVE PATHS
             # remove non existing (not marked) files\dirs
-            Log.info('Start remove non existing paths')
-            $testing_memory_log.info('Start remove non existing paths') if $testing_memory_active
+            log_msg = 'Start remove non existing paths'
+            Log.info(log_msg)
+            $testing_memory_log.info(log_msg) if $testing_memory_active
             dir_stat[0].removed_unmarked_paths
-            Log.info('End monitor path and index')
-            $testing_memory_log.info('End monitor path and index') if $testing_memory_active
+            log_msg = 'End monitor path and index'
+            Log.info(log_msg)
+            $testing_memory_log.info(log_msg) if $testing_memory_active
           }
 
           # ------ WRITE CONTENT DATA

--- a/lib/file_monitoring/file_monitoring.rb
+++ b/lib/file_monitoring/file_monitoring.rb
@@ -61,19 +61,17 @@ module FileMonitoring
         Log.info("Start build data base from loaded file. This could take several minutes")
         inst_count = 0
         $local_content_data.each_instance {
-            |checksum, size, _, mod_time, _, path|
+            |checksum, size, _, mod_time, _, path, index_time|
 
           if Params['manual_file_changes']
             file_attr_str = File.basename(path) + size.to_s + mod_time.to_s
             ident_file_info = $file_attr_to_checksum[file_attr_str]
             unless ident_file_info
               #  Add file checksum to map
-              $file_attr_to_checksum[file_attr_str] = IdentFileInfo.new(checksum)
-              puts "Added file:#{file_attr_str} to map"
+              $file_attr_to_checksum[file_attr_str] = IdentFileInfo.new(checksum, index_time)
             else
               # File already in map. Need to mark as not unique
               ident_file_info.unique = false  # file will be skipped if found at new location
-              puts "File #{file_attr_str} already exists"
             end
           end
           # construct sub paths array from full file path:

--- a/lib/file_monitoring/monitor_path.rb
+++ b/lib/file_monitoring/monitor_path.rb
@@ -363,7 +363,7 @@ module FileMonitoring
             else
               # --------------------- MANUAL MODE
               # check if file name and attributes exist in global file attr map
-              file_attr_str = File.basename(globed_path)+globed_path_stat.size+globed_path_stat.mtime.to_i
+              file_attr_str = File.basename(globed_path) + globed_path_stat.size.to_s + globed_path_stat.mtime.to_i.to_s
               file_ident_info = $file_attr_to_checksum[file_attr_str]
               # If not found (real new file) or found but not unique then file needs indexing. skip in manual mode.
               next unless file_ident_info and file_ident_info.unique

--- a/lib/file_monitoring/monitor_path.rb
+++ b/lib/file_monitoring/monitor_path.rb
@@ -369,7 +369,7 @@ module FileMonitoring
               # If not found (real new file) or found but not unique then file needs indexing. skip in manual mode.
 
               next unless (file_ident_info and file_ident_info.unique)
-              log.debug1("update content data with file:%s  checksum:%s  index_time:%s",
+              Log.debug1("update content data with file:%s  checksum:%s  index_time:%s",
                          File.basename(globed_path), file_ident_info.checksum, file_ident_info.index_time.to_s)
               # update content data (no need to update Dir tree)
               $local_content_data_lock.synchronize{

--- a/lib/file_monitoring/monitor_path.rb
+++ b/lib/file_monitoring/monitor_path.rb
@@ -318,6 +318,7 @@ module FileMonitoring
           if child_stat
             # -------------- EXISTS in Tree
             unless Params['manual_file_changes']
+              # --------- NON MANUAL MODE
               child_stat.marked = true
               if child_stat.changed?(globed_path_stat)
                 # ---------- STATUS CHANGED
@@ -333,7 +334,7 @@ module FileMonitoring
                 $local_content_data_lock.synchronize{
                   $local_content_data.remove_instance(Params['local_server_name'], globed_path)
                 }
-              else
+              else  # case child_stat did not change
                 # ---------- SAME STATUS
                 # File status is the same
                 if child_stat.state != FileStatEnum::STABLE
@@ -349,7 +350,7 @@ module FileMonitoring
                   end
                 end
               end
-            else
+            else  # case Params['manual_file_changes']
               # --------- MANUAL MODE
               child_stat.marked = true
             end
@@ -364,7 +365,7 @@ module FileMonitoring
               @@log.outputters[0].flush if Params['log_flush_each_message']
               child_stat.marked = true
               add_file(child_stat)
-            else
+            else  # case Params['manual_file_changes']
               # --------------------- MANUAL MODE
               # check if file name and attributes exist in global file attr map
               file_attr_key = [File.basename(globed_path), globed_path_stat.size, globed_path_stat.mtime.to_i]

--- a/lib/file_monitoring/monitor_path.rb
+++ b/lib/file_monitoring/monitor_path.rb
@@ -363,10 +363,21 @@ module FileMonitoring
             else
               # --------------------- MANUAL MODE
               # check if file name and attributes exist in global file attr map
+              puts "file:#{globed_path}  base name:#{File.basename(globed_path)}"
               file_attr_str = File.basename(globed_path) + globed_path_stat.size.to_s + globed_path_stat.mtime.to_i.to_s
               file_ident_info = $file_attr_to_checksum[file_attr_str]
               # If not found (real new file) or found but not unique then file needs indexing. skip in manual mode.
-              next unless file_ident_info and file_ident_info.unique
+              puts "NEW FILE: file_attr_str=#{file_attr_str}"
+              puts "unless file_ident_info and file_ident_info.unique = #{file_ident_info and file_ident_info.unique}"
+              if file_ident_info
+                puts "file_ident_info"
+                if file_ident_info.unique
+                  puts "file_ident_info.uniqu"
+                end
+             end
+
+              next unless (file_ident_info and file_ident_info.unique)
+              puts "update content data with file:#{File.basename(globed_path)}  checksum:#{file_ident_info.checksum}"
               # update content data (no need to update Dir tree)
               $local_content_data_lock.synchronize{
                 $local_content_data.add_instance(file_ident_info.checksum, globed_path_stat.size,

--- a/lib/file_monitoring/monitor_path.rb
+++ b/lib/file_monitoring/monitor_path.rb
@@ -23,9 +23,10 @@ module FileMonitoring
   #   ref_counter = number of references to same file which exist under several DirStat
   #   file_ref = ref to single shared FileStat object. (the last one which was created)
   class IdentFileInfo
-    attr_accessor :checksum, :unique
-    def initialize(checksum)
+    attr_accessor :checksum, :index_time, :unique
+    def initialize(checksum, index_time)
       @checksum = checksum
+      @index_time = index_time
       @unique = true
     end
   end
@@ -363,25 +364,21 @@ module FileMonitoring
             else
               # --------------------- MANUAL MODE
               # check if file name and attributes exist in global file attr map
-              puts "file:#{globed_path}  base name:#{File.basename(globed_path)}"
               file_attr_str = File.basename(globed_path) + globed_path_stat.size.to_s + globed_path_stat.mtime.to_i.to_s
               file_ident_info = $file_attr_to_checksum[file_attr_str]
               # If not found (real new file) or found but not unique then file needs indexing. skip in manual mode.
-              puts "NEW FILE: file_attr_str=#{file_attr_str}"
-              puts "unless file_ident_info and file_ident_info.unique = #{file_ident_info and file_ident_info.unique}"
-              if file_ident_info
-                puts "file_ident_info"
-                if file_ident_info.unique
-                  puts "file_ident_info.uniqu"
-                end
-             end
 
               next unless (file_ident_info and file_ident_info.unique)
-              puts "update content data with file:#{File.basename(globed_path)}  checksum:#{file_ident_info.checksum}"
+              log.debug1("update content data with file:%s  checksum:%s  index_time:%s",
+                         File.basename(globed_path), file_ident_info.checksum, file_ident_info.index_time.to_s)
               # update content data (no need to update Dir tree)
               $local_content_data_lock.synchronize{
-                $local_content_data.add_instance(file_ident_info.checksum, globed_path_stat.size,
-                                                 Params['local_server_name'], globed_path, globed_path_stat.mtime.to_i)
+                $local_content_data.add_instance(file_ident_info.checksum,
+                                                 globed_path_stat.size,
+                                                 Params['local_server_name'],
+                                                 globed_path,
+                                                 globed_path_stat.mtime.to_i,
+                                                 file_ident_info.index_time)
               }
             end
           end

--- a/spec/file_monitoring/monitor_path_spec.rb
+++ b/spec/file_monitoring/monitor_path_spec.rb
@@ -1,0 +1,43 @@
+require 'rspec'
+
+require_relative '../../lib/file_monitoring/monitor_path.rb'
+
+module FileMonitoring
+  module Spec
+
+    describe 'monitoring' do
+
+      # disabling log before running 'all' tests
+      before :all do
+        DirStat.set_log(nil)
+      end
+
+      # Test will create a monitoring directory.
+      # Test will setup dummy files for glob.
+      #   1st file is a regular file. 2nd file is a symlink file.
+      # Test will check that regular file added to dir
+      # Test will check the symlink file was ignored (not added to dir)
+      it 'should ignore symlink files during monitoring' do
+
+        # create the directory
+        dir_stat = DirStat.new('temp_path')
+
+        # define stubs for: glob, symlink checks and file status object(lstat).
+        Dir.stub(:glob).with('temp_path/*').and_return(['regular_file','symlink_file'])
+        File.stub(:symlink?).with('regular_file').and_return(false)
+        File.stub(:symlink?).with('symlink_file').and_return(true)
+        return_lstat = File.lstat(__FILE__)
+        File.stub(:lstat).with(any_args).and_return(return_lstat)
+
+        # Perform monitoring
+        dir_stat.monitor
+
+        # check that 'regular_file' was added to Dir
+        dir_stat.instance_eval{@files}['regular_file'].nil?.should be(false)
+        # check that 'symlink_file' was ignored( not added to Dir)
+        dir_stat.instance_eval{@files}['symlink_file'].nil?.should be(true)
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Summary of solution for this branch:
User flow:
1. Stop the application
2. Run Do manual changes in monitoring directories (any change)
3. Run the application with new flag: manual_file_change=true
4. Application should provide new content data file with the manual changes (without doing any indexing), and exit
5. Run application again with new flag: manual_file_change=false (default calue). Application will load the uchanged content data file and continue

Alogorithm for step 3:
  load content data with new flag: 'manual_file_change'
  During load the application will builld new map:
    file,size,mod --> [checksum, uniqu]
  If key found more then 1 time,then uniqu become false. This will indicate not to do anything with it during manual change

  monitoring new behavior:
    existing files in Application Tree - ignore
    new found files in OS system:
      If not exist in map - need to be indexed. skip (will be handled in step 5.
      If exist in map (copied or moved):
        if uniqu is true - take the original checksum and add to ContentData
        if uniqu is false - need to be indexed. skip. will be handled in step 5.
    unmarked files (non existing) - will have legacy behavior and be remove from content data
  Write new content data to file
  Exit the application
