### PR TITLE
Issue260 diff performance

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -143,8 +143,22 @@ require_relative '../../#{src_rel_pathname}'
 end
 
 require 'rspec/core/rake_task'
-desc "Run specs"
+desc "Run specs (excluding performance)"
 RSpec::Core::RakeTask.new do |t|
+  t.rspec_opts = "--tag ~perf"
   t.pattern = ["./test/**/*_spec.rb", "./spec/**/*_spec.rb"]
 end
 
+# Run performance tests.
+# NOTE performance tests tagged with ':tag => true' tag.
+# NOTE can take a while to finish
+desc "Run performance specs"
+RSpec::Core::RakeTask.new(:perf) do |t|
+  t.rspec_opts = "--tag perf"
+  t.pattern = ["./test/**/*_spec.rb", "./spec/**/*_spec.rb"]
+end
+
+desc "Run all specs (including performance)"
+RSpec::Core::RakeTask.new(:all_specs) do |t|
+  t.pattern = ["./test/**/*_spec.rb", "./spec/**/*_spec.rb"]
+end

--- a/lib/content_data/content_data.rb
+++ b/lib/content_data/content_data.rb
@@ -767,7 +767,8 @@ module ContentData
     return ContentData.new(b) if a.nil?
     c = ContentData.new
     b.each_instance do |checksum, size, _, instance_mtime, server, path, index_time|
-      unless (a.instance_exists(path, server))
+      #unless (a.instance_exists(path, server))
+      unless (a.content_exists(checksum))
               c.add_instance(checksum,
                              size,
                              server,

--- a/lib/content_data/content_data.rb
+++ b/lib/content_data/content_data.rb
@@ -31,6 +31,8 @@ module ContentData
 
     CHUNK_SIZE = 5000
 
+    # NOTE Cloning is time/memory expensive operation.
+    # It is highly recomended to avoid it.
     def initialize(other = nil)
       if other.nil?
         @contents_info = {}  # Checksum --> [size, paths-->time(instance), time(content)]
@@ -763,11 +765,17 @@ module ContentData
   def self.remove(a, b)
     return nil if b.nil?
     return ContentData.new(b) if a.nil?
-    c = ContentData.new(b)  # create new cloned content C from B
-    # remove contents of A from newly cloned content A
-    a.each_content { |checksum, size, content_mod_time|
-      c.remove_content(checksum)
-    }
+    c = ContentData.new
+    b.each_instance do |checksum, size, _, instance_mtime, server, path, index_time|
+      unless (a.instance_exists(path, server))
+              c.add_instance(checksum,
+                             size,
+                             server,
+                             path,
+                             instance_mtime,
+                             index_time)
+      end
+    end
     c
   end
 

--- a/lib/file_indexing/index_agent.rb
+++ b/lib/file_indexing/index_agent.rb
@@ -7,7 +7,6 @@ require 'content_data'
 require 'file_indexing/indexer_patterns'
 require 'log'
 
-
 module FileIndexing
 ####################
 # Index Agent

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -12,7 +12,7 @@ require_relative '../../lib/content_data/content_data.rb'
 describe 'Content Data Performance Test' do
 
   NUMBER_INSTANCES = 350_000
-  MAX_CHECKSUM = NUMBER_INSTANCES  #1000
+  MAX_CHECKSUM = NUMBER_INSTANCES
   INSTANCE_SIZE = 1000
   SERVER = "server"
   PATH = "file_"
@@ -55,7 +55,7 @@ describe 'Content Data Performance Test' do
         [build_thread, timer_thread].each { |th| th.join }
 
         is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData build for #{NUMBER_INSTANCES} " +
+        msg = "ContentData init for #{NUMBER_INSTANCES} " +
           (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
 
         # main check
@@ -91,7 +91,7 @@ describe 'Content Data Performance Test' do
         [init_thread, timer_thread].each { |th| th.join }
 
         is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData build for #{NUMBER_INSTANCES} " +
+        msg = "ContentData init from exist object of #{NUMBER_INSTANCES} " +
           (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
 
         # main check
@@ -136,8 +136,8 @@ describe 'Content Data Performance Test' do
         [build_thread, timer_thread].each { |th| th.join }
 
         is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData build for #{NUMBER_INSTANCES} " +
-          (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
+        msg = "Init of 2 ContentData of #{NUMBER_INSTANCES} instances each " +
+          (is_succeeded ? "" : "not ") + "finished in #{timer} seconds"
 
         # main check
         #timer.should be < LIMIT_TIME, msg

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -40,7 +40,7 @@ describe 'Content Data Performance Test', :perf =>true do
 
   let (:terminator) { Limit.new(LIMIT_TIME, LIMIT_MEMORY) }
 
-  # Print-out status messages, taken from module variable.
+  # Print-out status messages
   after :each do
     unless (terminator.nil?)
       Log.debug1("#{self.class.description} #{example.description}: #{terminator.msg}")
@@ -58,9 +58,8 @@ describe 'Content Data Performance Test', :perf =>true do
     initialized_cd
   end
 
-  # TODO consider separate it to 2 derived classes: one for memory, one for time monitoring
+  # TODO consider to separate it to 2 derived classes: one for memory, one for time monitoring
   class Limit
-    # elapsed time in seconds since timer was run or zero
     attr_reader :elapsed_time, :memory_usage, :msg
 
     def initialize(time_limit, memory_limit)
@@ -71,7 +70,6 @@ describe 'Content Data Performance Test', :perf =>true do
       @memory_limit = memory_limit
     end
 
-    # TODO consider usage of Process::setrlimit
     def get_timer_thread(watched_thread)
       Thread.new do
         while (@elapsed_time < @time_limit && watched_thread.alive?)
@@ -87,7 +85,6 @@ describe 'Content Data Performance Test', :perf =>true do
       end
     end
 
-    # TODO consider usage of Process::setrlimit
     def get_memory_limit_thread(watched_thread)
       Thread.new do
         init_memory_usage = Process.get_memory_usage
@@ -106,10 +103,11 @@ describe 'Content Data Performance Test', :perf =>true do
     end
   end
 
-  # TODO consider adding more general method call_with_limit
+  # TODO consider more general public method call_with_limit
   class Proc
     # Run a procedure.
     # Terminate it if it is running more then a time limit
+    # TODO consider usage of Process::setrlimit
     # @param [Limit] limit object
     def call_with_timer(limit)
       call_thread = Thread.new { self.call }
@@ -119,6 +117,7 @@ describe 'Content Data Performance Test', :perf =>true do
 
     # Run a procedure.
     # Terminate it if it is running more then a memory limit
+    # TODO consider usage of Process::setrlimit
     # @param [Limit] limit object
     def call_with_memory_limit(limit)
       call_thread = Thread.new { self.call }

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -175,7 +175,7 @@ describe 'Content Data Performance Test', :perf =>true do
         cd1.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "clone of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds" do
+      it "clone of #{NUMBER_INSTANCES} in less then #{LIMIT_TIME} seconds" do
         cd2 = nil
         clone_proc = Proc.new { cd2 = ContentData::ContentData.new(@test_cd) }
         clone_proc.call_with_timer(terminator)

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -9,8 +9,8 @@ require 'tempfile'
 require_relative '../../lib/content_data/content_data.rb'
 
 # NOTE the results are not exact cause they do not run in a clean environment and influenced from
-# monitoring, testing code, but they give a good approximation
-# Supposition: monitoring code penalty is insignificant against time/memory usage of tested code
+# monitoring/testing code, but they give a good approximation
+# Supposition: monitoring code penalty is insignificant against time/memory usage of the tested code
 describe 'Content Data Performance Test', :perf =>true do
 
   NUMBER_INSTANCES = 350_000

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -6,10 +6,9 @@ end
 
 require 'rspec'
 require 'tempfile'
-#require 'random'
 require_relative '../../lib/content_data/content_data.rb'
 
-describe 'Content Data Performance Test' do
+describe ContentData, ' Performance Test' do
 
   NUMBER_INSTANCES = 350_000
   MAX_CHECKSUM = NUMBER_INSTANCES
@@ -18,8 +17,8 @@ describe 'Content Data Performance Test' do
   PATH = "file_"
   MTIME = 1000
 
-  LIMIT_MEMORY = 1024**3  # 1 GB
-  LIMIT_TIME = 10*60;  # 10 minutes
+  LIMIT_MEMORY = 300*(1024**2)  # 300 MB
+  LIMIT_TIME = 5*60;  # 5 minutes
 
   before :all do
     Params.init Array.new
@@ -31,7 +30,31 @@ describe 'Content Data Performance Test' do
     Log.init
   end
 
-  class TimerThread
+  before :each do
+   @msg = String.new
+  end
+
+  # Print-out status messages, taken from module variable.
+  after :each do
+    Log.debug1(@msg) unless (@msg.nil? || @msg.empty?)
+  end
+
+  # module variable contains an initialized ContentData
+  let (:test_cd) { get_initialized }
+  # used to printout messages after tests
+  let (:msg) { String.new }
+
+  # Initialize ContentData object with generated instances
+  # @return [ContentData] an initialized object
+  def get_initialized
+    initialized_cd = ContentData::ContentData.new
+    NUMBER_INSTANCES.times do |i|
+      initialized_cd.add_instance(i.to_s, INSTANCE_SIZE+i, SERVER, PATH + i.to_s, MTIME+i)
+    end
+    initialized_cd
+  end
+
+  class Timer
     # elapsed time in seconds since timer was run or zero
     attr_reader :elapsed_time
 
@@ -45,10 +68,67 @@ describe 'Content Data Performance Test' do
           @elapsed_time += 1
           sleep 1
         end
+        is_succeeded = true
         if (watched_thread.alive?)
           Thread.kill(watched_thread)
+          is_succeeded = false
         end
+       @msg = (is_succeeded ? "" : "do not ") + "finished in #{@elapsed_time} seconds"
       end
+    end
+  end
+
+  class Proc
+    # Run a procedure.
+    # Terminate it if it is running more then a LIMIT_TIME
+    # TODO consider usage of Process::setrlimit(:CPU, LIMIT_TIME) instead
+    # @return [Integer] elapsed time
+    def call_with_timer
+      call_thread = Thread.new { self.call }
+      timer = Timer.new
+      timer_thread = timer.get_timer_thread(call_thread)
+      [call_thread, timer_thread].each { |th| th.join }
+      timer.elapsed_time
+    end
+  end
+
+  module Process
+    # @return [boolean] true when process alive, false otherwise
+    # @raise [Errno::EPERM] if process owned by other user, and there is no permissions to check
+    #   (not our case)
+    def Process.alive?(pid)
+      begin
+        Process.kill(0, pid)
+        true
+      rescue Errno::ESRCH
+        false
+      end
+    end
+
+    # Get memory consumed my the process
+    # @param [Integer] pid, default is current pid
+    def Process.get_memory_usage(pid = Process.pid)
+      if Gem::win_platform?
+        `tasklist /FI \"PID eq #{pid}\" /NH /FO \"CSV\"`.split(',')[4]
+      else
+        `ps -o rss= -p #{pid}`.to_i
+      end
+    end
+  end
+
+  # Means less than.
+  # Added for better readability.
+  RSpec::Matchers.define :end_not_later_than_within do |expected|
+    match do |actual|
+      actual < expected
+    end
+  end
+
+  # Means less than.
+  # Added for better readability.
+  RSpec::Matchers.define :consume_less_memory_than do |expected|
+    match do |actual|
+      actual < expected
     end
   end
 
@@ -56,339 +136,244 @@ describe 'Content Data Performance Test' do
     context 'Init one object' do
       it "#{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds" do
         cd1 = nil
-        build_thread = Thread.new do
-          cd1 = ContentData::ContentData.new
-          NUMBER_INSTANCES.times do |i|
-            cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-          end
-        end
-
-        timer = 0
-        timer_thread = Thread.new do
-          while (timer < LIMIT_TIME && build_thread.alive?)
-            timer += 1
-            sleep 1
-          end
-          if (build_thread.alive?)
-            Thread.kill(build_thread)
-          end
-        end
-        [build_thread, timer_thread].each { |th| th.join }
-
-        is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData init for #{NUMBER_INSTANCES} instances" +
-          (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
-
-        # main check
-        #timer.should be < LIMIT_TIME, msg
-        is_succeeded.should be_true
+        init_proc = Proc.new { cd1 = get_initialized }
+        expect {
+          elapsed_time = init_proc.call_with_timer
+          puts elapsed_time
+          elapsed_time
+        }.to end_not_later_than_within LIMIT_TIME
 
         # checks that test was correct
-        if is_succeeded
-          cd1.should be
-          cd1.instances_size.should == NUMBER_INSTANCES
-        end
-        Log.debug1(msg)
+        cd1 = nil
+        cd1.should be
+        #cd1.instances_size.should == NUMBER_INSTANCES
+        @msg = "FAILED"
+        puts "EXIT"
       end
 
-      it "clone from exist object of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds" do
-        cd1 = ContentData::ContentData.new
-        NUMBER_INSTANCES.times do |i|
-          cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-        end
+      xit "clone from exist object of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds" do
         cd2 = nil
-        init_thread = Thread.new { cd2 = ContentData::ContentData.new(cd1) }
+        clone_proc = Proc.new { cd2 = ContentData::ContentData.new(test_cd) }
+        clone_proc.call_with_timer.should end_not_later_than_within LIMIT_TIME
 
-        timer = 0
-        timer_thread = Thread.new do
-          while (timer < LIMIT_TIME && init_thread.alive?)
-            timer += 1
-            sleep 1
-          end
-          if (init_thread.alive?)
-            Thread.kill(init_thread)
-          end
-        end
-        [init_thread, timer_thread].each { |th| th.join }
-
-        is_succeeded = timer < LIMIT_TIME
-        msg = "Clone from exist object of #{NUMBER_INSTANCES} instances " +
-          (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
-
-        # main check
-        #timer.should be < LIMIT_TIME, msg
-        is_succeeded.should be_true
-
-        # checks that test was correct
-        if is_succeeded
-          cd2.should be
-          cd2.instances_size.should == NUMBER_INSTANCES
-        end
-
-        Log.debug1(msg)
+        # checks that test
+        cd2.should be
+        cd2.instances_size.should == test_cd.instances_size
       end
     end
 
+    # Used to check how number of ContentData objects, presented simultaneously in the system,
+    # influence the system performence
     context 'Init more then one object' do
-      it "two object of #{NUMBER_INSTANCES} instances each in less then #{2*LIMIT_TIME} seconds" do
+      xit "two object of #{NUMBER_INSTANCES} instances each in less then #{2*LIMIT_TIME} seconds" do
         cd1 = nil
         cd2 = nil
-        build_thread = Thread.new do
-          cd1 = ContentData::ContentData.new
-          NUMBER_INSTANCES.times do |i|
-            cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-          end
-          cd2 = ContentData::ContentData.new
-          NUMBER_INSTANCES.times do |i|
-            cd2.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-          end
+        build_proc = Proc.new do
+          cd1 = get_initialized
+          cd2 = get_initialized
         end
-
-        timer = 0
-        timer_thread = Thread.new do
-          while (timer < LIMIT_TIME && build_thread.alive?)
-            timer += 1
-            sleep 1
-          end
-          if (build_thread.alive?)
-            Thread.kill(build_thread)
-          end
-        end
-        [build_thread, timer_thread].each { |th| th.join }
-
-        is_succeeded = timer < LIMIT_TIME
-        msg = "Init of 2 ContentData of #{NUMBER_INSTANCES} instances each " +
-          (is_succeeded ? "" : "not ") + "finished in #{timer} seconds"
-
-        # main check
-        #timer.should be < LIMIT_TIME, msg
-        is_succeeded.should be_true
+        build_proc.call_with_timer.should end_not_later_than_within 2*LIMIT_TIME
 
         # checks that test was correct
-        if is_succeeded
-          cd1.should be
-          cd1.instances_size.should == NUMBER_INSTANCES
-          cd2.should be
-          cd2.instances_size.should == NUMBER_INSTANCES
-        end
-
-        Log.debug1(msg)
+        cd1.should be
+        cd1.instances_size.should == NUMBER_INSTANCES
+        cd2.should be
+        cd2.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "three object of #{NUMBER_INSTANCES} instances each in less then #{3*LIMIT_TIME} seconds" do
+      xit "three object of #{NUMBER_INSTANCES} instances each in less then #{3*LIMIT_TIME} seconds" do
         cd1 = nil
         cd2 = nil
         cd3 = nil
-        build_thread = Thread.new do
-          cd1 = ContentData::ContentData.new
-          NUMBER_INSTANCES.times do |i|
-            cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-          end
-          cd2 = ContentData::ContentData.new
-          NUMBER_INSTANCES.times do |i|
-            cd2.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-          end
-          cd3 = ContentData::ContentData.new
-          NUMBER_INSTANCES.times do |i|
-            cd3.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-          end
+        build_proc = Proc.new do
+          cd1 = get_initialized
+          cd2 = get_initialized
+          cd3 = get_initialized
         end
-
-        timer = 0
-        timer_thread = Thread.new do
-          while (timer < LIMIT_TIME && build_thread.alive?)
-            timer += 1
-            sleep 1
-          end
-          if (build_thread.alive?)
-            Thread.kill(build_thread)
-          end
-        end
-        [build_thread, timer_thread].each { |th| th.join }
-
-        is_succeeded = timer < LIMIT_TIME
-        msg = "Init of 3 ContentData of #{NUMBER_INSTANCES} instances each " +
-          (is_succeeded ? "" : "not ") + "finished in #{timer} seconds"
-
-        # main check
-        #timer.should be < LIMIT_TIME, msg
-        is_succeeded.should be_true
+        build_proc.call_with_timer.should end_not_later_than_within 3*LIMIT_TIME
 
         # checks that test was correct
-        if is_succeeded
-          cd1.should be
-          cd1.instances_size.should == NUMBER_INSTANCES
-          cd2.should be
-          cd2.instances_size.should == NUMBER_INSTANCES
-          cd3.should be
-          cd3.instances_size.should == NUMBER_INSTANCES
-        end
-
-        Log.debug1(msg)
+        cd1.should be
+        cd1.instances_size.should == NUMBER_INSTANCES
+        cd2.should be
+        cd2.instances_size.should == NUMBER_INSTANCES
+        cd3.should be
+        cd3.instances_size.should == NUMBER_INSTANCES
       end
+    end
+  end
+
+  context 'Iteration' do
+    xit "each instance on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME}" do
+      each_thread = Proc.new { test_cd.each_instance { |ch,_,_,_,_,_,_| ch } }
+      each_thread.call_with_timer.should end_not_later_than_within LIMIT_TIME
     end
   end
 
   context 'File operations' do
     before :all do
-      @cd1 = ContentData::ContentData.new
-      NUMBER_INSTANCES.times do |i|
-        @cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-      end
       @file = Tempfile.new('to_file_test')
+      @path = @file.path
     end
 
     after :all do
       @file.close!
     end
 
-    it "save/load on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds" do
+    xit "save/load on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds" do
       # Checking to_file
-      timer = 0
-      begin
-        to_file_thread = Thread.new do
-          path = @file.path
-          @cd1.to_file(path)
+      to_file_proc = Proc.new do
+        begin
+          test_cd.to_file(@path)
+        ensure
+          @file.close
         end
-
-        timer_thread = Thread.new do
-          while (timer < LIMIT_TIME && to_file_thread.alive?)
-            timer += 1
-            sleep 1
-          end
-          if (to_file_thread.alive?)
-            Thread.kill(to_file_thread)
-          end
-        end
-        [to_file_thread, timer_thread].each { |th| th.join }
-      ensure
-        @file.close
       end
-
-      is_succeeded = timer < LIMIT_TIME
-      msg = "To file for #{NUMBER_INSTANCES} instances " +
-        (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
-
-      # main check
-      #timer.should be < LIMIT_TIME, msg
-      is_succeeded.should be_true
-      Log.debug1(msg)
+      to_file_proc.call_with_timer.should end_not_later_than_within LIMIT_TIME
 
       # checking from_file
-      timer = TimerThread.new
       cd2 = ContentData::ContentData.new
-      begin
-        from_file_thread = Thread.new do
-          path = @file.path
-          cd2.from_file(path)
+      from_file_proc = Proc.new do
+        begin
+          cd2.from_file(@path)
+        ensure
+          @file.close
         end
-
-
-        timer_thread = timer.get_timer_thread(from_file_thread)
-        [from_file_thread, timer_thread].each { |th| th.join }
-      ensure
-        @file.close
       end
-
-      is_succeeded = timer.elapsed_time < LIMIT_TIME
-      msg = "From file for #{NUMBER_INSTANCES} instances " +
-        (is_succeeded ? "" : "do not ") + "finished in #{timer.elapsed_time} seconds"
-
-      # main check
-      #timer.should be < LIMIT_TIME, msg
-      is_succeeded.should be_true
+      from_file_proc.call_with_timer.should end_not_later_than_within LIMIT_TIME
 
       # checks that test was correct
-      if is_succeeded
-        @cd1.instances_size.should == cd2.instances_size
-      end
-
-      Log.debug1(msg)
-
+      cd2.instances_size.should == test_cd.instances_size
     end
   end
 
-  context 'Set operations' do
+  describe 'Set operations' do
     before :all do
-      @cd1 = ContentData::ContentData.new
-      NUMBER_INSTANCES.times do |i|
-        @cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-      end
-      @cd2 = ContentData::ContentData.new
-      NUMBER_INSTANCES.times do |i|
-        @cd2.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
-      end
+      @cd2 = get_initialized
       @cd2.add_instance((MAX_CHECKSUM+1).to_s, INSTANCE_SIZE, SERVER, PATH + "new", MTIME)
     end
 
     context "minus of two objects with #{NUMBER_INSTANCES} instances each" do
-      it "finish in less then #{LIMIT_TIME} seconds" do
+      xit "finish in less then #{LIMIT_TIME} seconds" do
         res_cd = nil
-        minus_thread = Thread.new { res_cd = ContentData.remove(@cd1, @cd2) }
-
-        timer = 0
-        timer_thread = Thread.new do
-          while (timer < LIMIT_TIME && minus_thread.alive?)
-            timer += 1
-            sleep 1
-          end
-          if (minus_thread.alive?)
-            Thread.kill(minus_thread)
-          end
-        end
-        [minus_thread, timer_thread].each { |th| th.join }
-
-        is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData minus for #{NUMBER_INSTANCES} instances " +
-          (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
-
-        # main check
-        #timer.should be < LIMIT_TIME, msg
-        is_succeeded.should be_true
+        minus_proc = Proc.new { res_cd = ContentData.remove(test_cd, @cd2) }
+        minus_proc.call_with_timer.should end_not_later_than_within LIMIT_TIME
 
         # checks that test was correct
-        if is_succeeded
-          res_cd.should be
-          res_cd.instances_size.should == 1
-        end
-
-        Log.debug1(msg)
+        res_cd.should be
+        res_cd.instances_size.should == 1
       end
 
-      pending "consume less then #{LIMIT_MEMORY} bytes" do
+      xit "(no cloning) finish in less then #{LIMIT_TIME} seconds" do
+        res_cd = nil
+        minus_proc = Proc.new { res_cd = ContentData.remove_no_cloning(test_cd, @cd2) }
+        minus_proc.call_with_timer.should end_not_later_than_within LIMIT_TIME
 
-        minus_thread = Thread.new { res_cd = ContentData.remove(@cd1, @cd2) }
+        # checks that test was correct
+        res_cd.should be
+        res_cd.instances_size.should == 1
+      end
 
+      xit "consume less then #{LIMIT_MEMORY} bytes" do
+        res_cd = nil
         memory_of_process = 0
+        GC.start
+        init_memory_usage = Process.get_memory_usage
+        minus_thread = Thread.new { res_cd = ContentData.remove(test_cd, @cd2) }
+
+        Log.debug1("Memory before: #{init_memory_usage}")
         memory_usage_thread = Thread.new do
-          while (memory_of_process < LIMIT_MEMORY && minus_thread.alive?)
-            memory_of_process = if Gem::win_platform?
-                                  `tasklist /FI \"PID eq #{Process.pid}\" /NH /FO \"CSV\"`.split(',')[4]
-                                else
-                                  `ps -o rss= -p #{Process.pid}`.to_i / 1000
-                                end
-            puts Process.pid + " => " + memory_of_process
+          Log.debug1("Current: #{Process.pid}")
+          begin
+            memory_of_process = Process.get_memory_usage - init_memory_usage
             sleep 1
-          end
+          end while (memory_of_process < LIMIT_MEMORY && minus_thread.alive?)
           if (minus_thread.alive?)
             Thread.kill(minus_thread)
           end
+          Log.debug1("memory usage: #{memory_of_process}")
         end
+        [minus_thread, memory_usage_thread].each { |th| th.join }
+        Log.debug1("Memory after: #{init_memory_usage + memory_of_process}")
+        memory_of_process.should < LIMIT_MEMORY
 
-        is_succeeded = memory_of_process
-        msg = "ContentData minus for #{NUMBER_INSTANCES} " +
-          (is_succeeded ? "" : "do not ") + "consume #{memory_of_process} bytes"
+        res_cd.should be
+        res_cd.instances_size.should == 1
+      end
 
-        # main check
-        #timer.should be < LIMIT_TIME, msg
-        is_succeeded.should be_true
-        puts msg if is_succeeded
+      xit "(no cloning) consume less then #{LIMIT_MEMORY} bytes" do
+        res_cd = nil
+        memory_of_process = 0
+        GC.start
+        init_memory_usage = Process.get_memory_usage
+        minus_thread = Thread.new { res_cd = ContentData.remove_no_cloning(test_cd, @cd2) }
 
-        # checks that test was correct
-        if is_succeeded
+        Log.debug1("Memory before: #{init_memory_usage}")
+        memory_usage_thread = Thread.new do
+          Log.debug1("Current: #{Process.pid}")
+          begin
+            memory_of_process = Process.get_memory_usage - init_memory_usage
+            sleep 1
+          end while (memory_of_process < LIMIT_MEMORY && minus_thread.alive?)
+          if (minus_thread.alive?)
+            Thread.kill(minus_thread)
+          end
+          Log.debug1("memory usage: #{memory_of_process}")
+        end
+        [minus_thread, memory_usage_thread].each { |th| th.join }
+        Log.debug1("Memory after: #{init_memory_usage + memory_of_process}")
+        memory_of_process.should < LIMIT_MEMORY
+
+        res_cd.should be
+        res_cd.instances_size.should == 1
+      end
+
+      xit "(no cloning, using Process) consume less then #{LIMIT_MEMORY} bytes" do
+        GC.start
+        minus_pid = Process.fork do
+          res_cd = ContentData.remove_no_cloning(test_cd, @cd2)
           res_cd.should be
           res_cd.instances_size.should == 1
+          exit(0)
         end
+        Process.detach(minus_pid)
+        memory_of_process = 0
+        init_memory_usage = Process.get_memory_usage(minus_pid)
+        cur_memory_usage = init_memory_usage
+        Log.debug1("Current: #{Process.pid}")
+        Log.debug1("Minus PID: #{minus_pid}")
+        Log.debug1("Memory usage before #{init_memory_usage}")
+        #is_minus_process_alive = true
+        #is_monitoring_failed = false
+        begin
+          cur_memory_usage = Process.get_memory_usage(minus_pid)
+          memory_of_process = cur_memory_usage - init_memory_usage if cur_memory_usage > 0
+          sleep 1
+        end while (memory_of_process < LIMIT_MEMORY && Process.alive?(minus_pid))
+
+        if (Process.alive?(minus_pid))
+          Process.kill(2, minus_pid)
+        end
+
+        Log.debug1("Memory usage after: #{cur_memory_usage}")
+        Log.debug1("Memory of process: #{memory_of_process}")
+        memory_of_process.should < LIMIT_MEMORY
+      end
+
+      xit "(no cloning, using Process limit) consume less then #{LIMIT_MEMORY} bytes" do
+        #GC.start
+        minus_pid = Process.fork do
+          Log.debug1("Current: #{Process.pid}")
+          puts (Process.getrlimit(:DATA))
+          Process.setrlimit(:DATA, 10, 10) #Process.get_memory_usage, Process.get_memory_usage)
+          puts (Process.getrlimit(:DATA))
+          res_cd = ContentData.remove_no_cloning(test_cd, @cd2)
+          res_cd.should be
+          res_cd.instances_size.should == 1
+          exit(0)
+        end
+        Process.wait(minus_pid)
+        $?.success?.should be_true
       end
     end
   end

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -240,7 +240,7 @@ describe 'Content Data Performance Test' do
 
       is_succeeded = timer.elapsed_time < LIMIT_TIME
       msg = "From file for #{NUMBER_INSTANCES} " +
-        (is_succeeded ? "" : "do not ") + "finished in #{timer.get_elapsed_time} seconds"
+        (is_succeeded ? "" : "do not ") + "finished in #{timer.elapsed_time} seconds"
 
       # main check
       #timer.should be < LIMIT_TIME, msg

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -24,7 +24,7 @@ describe 'Content Data Performance Test', :perf =>true do
   MTIME = 1000
 
   # in kilobytes
-  LIMIT_MEMORY = 200*(1024)  # 200 MB
+  LIMIT_MEMORY = 250*(1024)  # 250 MB
   # in seconds
   LIMIT_TIME = 5*60;  # 5 minutes
 

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -6,9 +6,6 @@ end
 
 require 'rspec'
 require 'tempfile'
-#require 'random'
-require 'benchmark'
-#require 'ruby-prof'
 require_relative '../../lib/content_data/content_data.rb'
 
 # NOTE the results are not exact cause they do not run in a clean environment and influenced from

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -22,12 +22,13 @@ describe 'Content Data Performance Test' do
     SERVER = "server"
     PATH = "file_"
     MTIME = 1000
+
+    LIMIT_TIME = 10*60;  # 10 minutes
+    LIMIT_MEMORY = 100*1024
   end
 
   context 'IO operations' do
     it 'should create ContentData object in acceptable period of time' do
-      LIMIT_TIME = 10*60;  # 10 minutes
-
       build_thread = Thread.new do
         @cd1 = ContentData::ContentData.new
         NUMBER_INSTANCES.times do |i|
@@ -64,8 +65,6 @@ describe 'Content Data Performance Test' do
     end
 
     it 'should init new ContentData object from exist one in acceptable period of time' do
-      LIMIT_TIME = 10*60;  # 10 minutes
-
       init_thread = Thread.new { @cd2 = ContentData::ContentData.new(@cd1) }
 
       timer = 0
@@ -110,7 +109,6 @@ describe 'Content Data Performance Test' do
 
     pending 'should consume acceptable amount of memory' do
       puts "Memory usage test"
-      LIMIT_MEMORY = 100*1024
 
       minus_thread = Thread.new { res_cd = ContentData.remove(@cd1, @cd2) }
 

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -91,7 +91,7 @@ describe 'Content Data Performance Test' do
         Log.debug1(msg)
       end
 
-      it "from exist object of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds" do
+      it "clone from exist object of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds" do
         cd1 = ContentData::ContentData.new
         NUMBER_INSTANCES.times do |i|
           cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
@@ -112,7 +112,7 @@ describe 'Content Data Performance Test' do
         [init_thread, timer_thread].each { |th| th.join }
 
         is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData init from exist object of #{NUMBER_INSTANCES} instances " +
+        msg = "Clone from exist object of #{NUMBER_INSTANCES} instances " +
           (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
 
         # main check
@@ -130,7 +130,7 @@ describe 'Content Data Performance Test' do
     end
 
     context 'Init more then one object' do
-      it "two object each of #{NUMBER_INSTANCES} instances in less then #{2*LIMIT_TIME} seconds" do
+      it "two object of #{NUMBER_INSTANCES} instances each in less then #{2*LIMIT_TIME} seconds" do
         cd1 = nil
         cd2 = nil
         build_thread = Thread.new do
@@ -170,6 +170,58 @@ describe 'Content Data Performance Test' do
           cd1.instances_size.should == NUMBER_INSTANCES
           cd2.should be
           cd2.instances_size.should == NUMBER_INSTANCES
+        end
+
+        Log.debug1(msg)
+      end
+
+      it "three object of #{NUMBER_INSTANCES} instances each in less then #{3*LIMIT_TIME} seconds" do
+        cd1 = nil
+        cd2 = nil
+        cd3 = nil
+        build_thread = Thread.new do
+          cd1 = ContentData::ContentData.new
+          NUMBER_INSTANCES.times do |i|
+            cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
+          end
+          cd2 = ContentData::ContentData.new
+          NUMBER_INSTANCES.times do |i|
+            cd2.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
+          end
+          cd3 = ContentData::ContentData.new
+          NUMBER_INSTANCES.times do |i|
+            cd3.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
+          end
+        end
+
+        timer = 0
+        timer_thread = Thread.new do
+          while (timer < LIMIT_TIME && build_thread.alive?)
+            timer += 1
+            sleep 1
+          end
+          if (build_thread.alive?)
+            Thread.kill(build_thread)
+          end
+        end
+        [build_thread, timer_thread].each { |th| th.join }
+
+        is_succeeded = timer < LIMIT_TIME
+        msg = "Init of 3 ContentData of #{NUMBER_INSTANCES} instances each " +
+          (is_succeeded ? "" : "not ") + "finished in #{timer} seconds"
+
+        # main check
+        #timer.should be < LIMIT_TIME, msg
+        is_succeeded.should be_true
+
+        # checks that test was correct
+        if is_succeeded
+          cd1.should be
+          cd1.instances_size.should == NUMBER_INSTANCES
+          cd2.should be
+          cd2.instances_size.should == NUMBER_INSTANCES
+          cd3.should be
+          cd3.instances_size.should == NUMBER_INSTANCES
         end
 
         Log.debug1(msg)
@@ -214,7 +266,7 @@ describe 'Content Data Performance Test' do
       end
 
       is_succeeded = timer < LIMIT_TIME
-      msg = "To file for #{NUMBER_INSTANCES} " +
+      msg = "To file for #{NUMBER_INSTANCES} instances " +
         (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
 
       # main check
@@ -239,7 +291,7 @@ describe 'Content Data Performance Test' do
       end
 
       is_succeeded = timer.elapsed_time < LIMIT_TIME
-      msg = "From file for #{NUMBER_INSTANCES} " +
+      msg = "From file for #{NUMBER_INSTANCES} instances " +
         (is_succeeded ? "" : "do not ") + "finished in #{timer.elapsed_time} seconds"
 
       # main check
@@ -287,7 +339,7 @@ describe 'Content Data Performance Test' do
         [minus_thread, timer_thread].each { |th| th.join }
 
         is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData minus for #{NUMBER_INSTANCES} " +
+        msg = "ContentData minus for #{NUMBER_INSTANCES} instances " +
           (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
 
         # main check

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -14,7 +14,7 @@ require_relative '../../lib/content_data/content_data.rb'
 # NOTE the results are not exact cause they do not run in a clean environment and influenced from
 # monitoring, testing code, but they give a good approximation
 # Supposition: monitoring code penalty is neglectable against time/memory usage of testsed code
-describe 'Content Data Performance Test' do
+describe 'Content Data Performance Test', :perf =>true do
 
   NUMBER_INSTANCES = 350_000
   MAX_CHECKSUM = NUMBER_INSTANCES
@@ -23,7 +23,9 @@ describe 'Content Data Performance Test' do
   PATH = "file_"
   MTIME = 1000
 
-  LIMIT_MEMORY = 50*(1024**2)  # 50 MB
+  # in kilobytes
+  LIMIT_MEMORY = 50*(1024)  # 50 MB
+  # in seconds
   LIMIT_TIME = 5*60;  # 10 minutes
 
   before :all do
@@ -143,6 +145,7 @@ describe 'Content Data Performance Test' do
 
     # Get memory consumed my the process
     # @param [Integer] pid, default is current pid
+    # @return [Integer] memory usage in kilobytes
     def Process.get_memory_usage(pid = Process.pid)
       if Gem::win_platform?
         `tasklist /FI \"PID eq #{pid}\" /NH /FO \"CSV\"`.split(',')[4]
@@ -154,7 +157,7 @@ describe 'Content Data Performance Test' do
 
   context 'Object initialization' do
     context 'Init one object' do
-      it "#{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds", :perf => true do
+      it "#{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds" do
         cd1 = nil
         init_proc = Proc.new { cd1 = get_initialized }
         init_proc.call_with_timer(terminator)
@@ -165,7 +168,7 @@ describe 'Content Data Performance Test' do
         cd1.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "#{NUMBER_INSTANCES} instances consumes less then #{LIMIT_MEMORY} bytes", :perf => true do
+      it "#{NUMBER_INSTANCES} instances consumes less then #{LIMIT_MEMORY} KB" do
         cd1 = nil
         init_proc = Proc.new { cd1 = get_initialized }
         init_proc.call_with_memory_limit(terminator)
@@ -176,7 +179,7 @@ describe 'Content Data Performance Test' do
         cd1.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "clone of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds", :perf => true do
+      it "clone of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds" do
         cd2 = nil
         clone_proc = Proc.new { cd2 = ContentData::ContentData.new(@test_cd) }
         clone_proc.call_with_timer(terminator)
@@ -187,7 +190,7 @@ describe 'Content Data Performance Test' do
         cd2.instances_size.should == @test_cd.instances_size
       end
 
-      it "clone of #{NUMBER_INSTANCES} consumes less then #{LIMIT_MEMORY} bytes", :perf => true do
+      it "clone of #{NUMBER_INSTANCES} consumes less then #{LIMIT_MEMORY} KB" do
         cd2 = nil
         clone_proc = Proc.new { cd2 = ContentData::ContentData.new(@test_cd) }
         clone_proc.call_with_memory_limit(terminator)
@@ -201,8 +204,7 @@ describe 'Content Data Performance Test' do
 
 
     context 'Init more then one object' do
-      it "two object of #{NUMBER_INSTANCES} instances each in less then #{2*LIMIT_TIME} seconds",
-        :perf => true do
+      it "two object of #{NUMBER_INSTANCES} instances each in less then #{2*LIMIT_TIME} seconds" do
         cd1 = nil
         cd2 = nil
         build_proc = Proc.new do
@@ -219,8 +221,7 @@ describe 'Content Data Performance Test' do
         cd2.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "three object of #{NUMBER_INSTANCES} instances each in less then #{3*LIMIT_TIME} seconds",
-        :perf => true do
+      it "three object of #{NUMBER_INSTANCES} instances each in less then #{3*LIMIT_TIME} seconds" do
         cd1 = nil
         cd2 = nil
         cd3 = nil
@@ -244,8 +245,7 @@ describe 'Content Data Performance Test' do
   end
 
   context 'Iteration' do
-    it "each instance on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME}",
-      :perf => true do
+    it "each instance on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME}" do
       each_thread = Proc.new { @test_cd.each_instance { |ch,_,_,_,_,_,_| ch } }
       each_thread.call_with_timer(terminator)
       terminator.elapsed_time.should < LIMIT_TIME
@@ -262,8 +262,7 @@ describe 'Content Data Performance Test' do
       @file.close!
     end
 
-    it "save/load on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds",
-      :perf => true do
+    it "save/load on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds" do
       # Checking to_file
       to_file_proc = Proc.new do
         begin
@@ -300,7 +299,7 @@ describe 'Content Data Performance Test' do
     end
 
     context "minus of two objects with #{NUMBER_INSTANCES} instances each" do
-      it "finish in less then #{LIMIT_TIME} seconds", :perf => true do
+      it "finish in less then #{LIMIT_TIME} seconds" do
         res_cd = nil
         minus_proc = Proc.new { res_cd = ContentData.remove(@test_cd, @cd2) }
         minus_proc.call_with_timer(terminator)
@@ -311,7 +310,7 @@ describe 'Content Data Performance Test' do
         res_cd.instances_size.should == 1
       end
 
-      it "consume less then #{LIMIT_MEMORY} bytes", :perf => true do
+      it "consume less then #{LIMIT_MEMORY} KB" do
         res_cd = nil
         minus_proc = Proc.new { res_cd = ContentData.remove(@test_cd, @cd2) }
         minus_proc.call_with_memory_limit(terminator)

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -10,7 +10,7 @@ require_relative '../../lib/content_data/content_data.rb'
 
 # NOTE the results are not exact cause they do not run in a clean environment and influenced from
 # monitoring, testing code, but they give a good approximation
-# Supposition: monitoring code penalty is neglectable against time/memory usage of testsed code
+# Supposition: monitoring code penalty is insignificant against time/memory usage of tested code
 describe 'Content Data Performance Test', :perf =>true do
 
   NUMBER_INSTANCES = 350_000

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -32,25 +32,23 @@ describe 'Content Data Performance Test' do
   end
 
   class TimerThread
+    # elapsed time in seconds since timer was run or zero
+    attr_reader :elapsed_time
+
     def initialize
-      @timer = 0
+      @elapsed_time = 0
     end
 
     def get_timer_thread(watched_thread)
       Thread.new do
-        while (@timer < LIMIT_TIME && watched_thread.alive?)
-          @timer += 1
+        while (@elapsed_time < LIMIT_TIME && watched_thread.alive?)
+          @elapsed_time += 1
           sleep 1
         end
         if (watched_thread.alive?)
           Thread.kill(watched_thread)
         end
       end
-    end
-
-    # @return [Integer] elapsed time in seconds since timer was run or zero
-    def get_elapsed_time
-      @timer.to_i
     end
   end
 
@@ -78,7 +76,7 @@ describe 'Content Data Performance Test' do
         [build_thread, timer_thread].each { |th| th.join }
 
         is_succeeded = timer < LIMIT_TIME
-        msg = "ContentData init for #{NUMBER_INSTANCES} " +
+        msg = "ContentData init for #{NUMBER_INSTANCES} instances" +
           (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
 
         # main check
@@ -234,13 +232,13 @@ describe 'Content Data Performance Test' do
         end
 
 
-        timer_thread = timer.get_timer_thread()
+        timer_thread = timer.get_timer_thread(from_file_thread)
         [from_file_thread, timer_thread].each { |th| th.join }
       ensure
         @file.close
       end
 
-      is_succeeded = timer.get_elapsed_time < LIMIT_TIME
+      is_succeeded = timer.elapsed_time < LIMIT_TIME
       msg = "From file for #{NUMBER_INSTANCES} " +
         (is_succeeded ? "" : "do not ") + "finished in #{timer.get_elapsed_time} seconds"
 

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -24,9 +24,9 @@ describe 'Content Data Performance Test', :perf =>true do
   MTIME = 1000
 
   # in kilobytes
-  LIMIT_MEMORY = 50*(1024)  # 50 MB
+  LIMIT_MEMORY = 150*(1024)  # 150 MB
   # in seconds
-  LIMIT_TIME = 5*60;  # 10 minutes
+  LIMIT_TIME = 5*60;  # 5 minutes
 
   before :all do
     Params.init Array.new

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -156,7 +156,7 @@ describe 'Content Data Performance Test' do
     end
   end
 
-  pending 'Set operations' do
+  context 'Set operations' do
     before :all do
       @cd1 = ContentData::ContentData.new
       NUMBER_INSTANCES.times do |i|

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -24,7 +24,7 @@ describe 'Content Data Performance Test', :perf =>true do
   MTIME = 1000
 
   # in kilobytes
-  LIMIT_MEMORY = 150*(1024)  # 150 MB
+  LIMIT_MEMORY = 200*(1024)  # 200 MB
   # in seconds
   LIMIT_TIME = 5*60;  # 5 minutes
 

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -154,7 +154,7 @@ describe 'Content Data Performance Test' do
 
   context 'Object initialization' do
     context 'Init one object' do
-      it "#{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds" do
+      it "#{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds", :perf => true do
         cd1 = nil
         init_proc = Proc.new { cd1 = get_initialized }
         init_proc.call_with_timer(terminator)
@@ -165,7 +165,7 @@ describe 'Content Data Performance Test' do
         cd1.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "#{NUMBER_INSTANCES} instances consumes less then #{LIMIT_MEMORY} bytes" do
+      it "#{NUMBER_INSTANCES} instances consumes less then #{LIMIT_MEMORY} bytes", :perf => true do
         cd1 = nil
         init_proc = Proc.new { cd1 = get_initialized }
         init_proc.call_with_memory_limit(terminator)
@@ -176,7 +176,7 @@ describe 'Content Data Performance Test' do
         cd1.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "clone of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds" do
+      it "clone of #{NUMBER_INSTANCES} in less thes #{LIMIT_TIME} seconds", :perf => true do
         cd2 = nil
         clone_proc = Proc.new { cd2 = ContentData::ContentData.new(@test_cd) }
         clone_proc.call_with_timer(terminator)
@@ -187,7 +187,7 @@ describe 'Content Data Performance Test' do
         cd2.instances_size.should == @test_cd.instances_size
       end
 
-      it "clone of #{NUMBER_INSTANCES} consumes less then #{LIMIT_MEMORY} bytes" do
+      it "clone of #{NUMBER_INSTANCES} consumes less then #{LIMIT_MEMORY} bytes", :perf => true do
         cd2 = nil
         clone_proc = Proc.new { cd2 = ContentData::ContentData.new(@test_cd) }
         clone_proc.call_with_memory_limit(terminator)
@@ -201,7 +201,8 @@ describe 'Content Data Performance Test' do
 
 
     context 'Init more then one object' do
-      it "two object of #{NUMBER_INSTANCES} instances each in less then #{2*LIMIT_TIME} seconds" do
+      it "two object of #{NUMBER_INSTANCES} instances each in less then #{2*LIMIT_TIME} seconds",
+        :perf => true do
         cd1 = nil
         cd2 = nil
         build_proc = Proc.new do
@@ -218,7 +219,8 @@ describe 'Content Data Performance Test' do
         cd2.instances_size.should == NUMBER_INSTANCES
       end
 
-      it "three object of #{NUMBER_INSTANCES} instances each in less then #{3*LIMIT_TIME} seconds" do
+      it "three object of #{NUMBER_INSTANCES} instances each in less then #{3*LIMIT_TIME} seconds",
+        :perf => true do
         cd1 = nil
         cd2 = nil
         cd3 = nil
@@ -242,7 +244,8 @@ describe 'Content Data Performance Test' do
   end
 
   context 'Iteration' do
-    it "each instance on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME}" do
+    it "each instance on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME}",
+      :perf => true do
       each_thread = Proc.new { @test_cd.each_instance { |ch,_,_,_,_,_,_| ch } }
       each_thread.call_with_timer(terminator)
       terminator.elapsed_time.should < LIMIT_TIME
@@ -259,7 +262,8 @@ describe 'Content Data Performance Test' do
       @file.close!
     end
 
-    it "save/load on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds" do
+    it "save/load on #{NUMBER_INSTANCES} instances in less then #{LIMIT_TIME} seconds",
+      :perf => true do
       # Checking to_file
       to_file_proc = Proc.new do
         begin
@@ -296,7 +300,7 @@ describe 'Content Data Performance Test' do
     end
 
     context "minus of two objects with #{NUMBER_INSTANCES} instances each" do
-      it "finish in less then #{LIMIT_TIME} seconds" do
+      it "finish in less then #{LIMIT_TIME} seconds", :perf => true do
         res_cd = nil
         minus_proc = Proc.new { res_cd = ContentData.remove(@test_cd, @cd2) }
         minus_proc.call_with_timer(terminator)
@@ -307,7 +311,7 @@ describe 'Content Data Performance Test' do
         res_cd.instances_size.should == 1
       end
 
-      it "consume less then #{LIMIT_MEMORY} bytes" do
+      it "consume less then #{LIMIT_MEMORY} bytes", :perf => true do
         res_cd = nil
         minus_proc = Proc.new { res_cd = ContentData.remove(@test_cd, @cd2) }
         minus_proc.call_with_memory_limit(terminator)

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -1,0 +1,150 @@
+# NOTE Code Coverage block must be issued before any of your application code is required
+if ENV['BBFS_COVERAGE']
+  require_relative '../spec_helper.rb'
+  SimpleCov.command_name 'content_data'
+end
+
+require 'rspec'
+require 'tempfile'
+#require 'random'
+require_relative '../../lib/content_data/content_data.rb'
+
+describe 'Content Data Performance Test' do
+  before :all do
+    Params.init Array.new
+    # must preced Log.init, otherwise log containing default values will be created
+    Params['log_write_to_file'] = false
+    Log.init
+
+    NUMBER_INSTANCES = 350_000
+    MAX_CHECKSUM = NUMBER_INSTANCES  #1000
+    INSTANCE_SIZE = 1000
+    SERVER = "server"
+    PATH = "file_"
+    MTIME = 1000
+  end
+
+  context 'IO operations' do
+    it 'should create ContentData object in acceptable amount of time' do
+      LIMIT_TIME = 10*60;  # 10 minutes
+
+      build_thread = Thread.new do
+        @cd1 = ContentData::ContentData.new
+        NUMBER_INSTANCES.times do |i|
+          @cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
+        end
+      end
+
+      timer = 0
+      timer_thread = Thread.new do
+        while (timer < LIMIT_TIME && build_thread.alive?)
+          timer += 1
+          sleep 1
+        end
+        if (build_thread.alive?)
+          Thread.kill(build_thread)
+        end
+      end
+      [build_thread, timer_thread].each { |th| th.join }
+
+      is_succeeded = timer < LIMIT_TIME
+      msg = "ContentData build for #{NUMBER_INSTANCES} " +
+        (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
+
+      # main check
+      #timer.should be < LIMIT_TIME, msg
+      is_succeeded.should be_true
+      puts msg if is_succeeded
+
+      # checks that test was correct
+      if is_succeeded
+        @cd1.should be
+      end
+
+    end
+  end
+
+  context 'Set operations' do
+    before :all do
+      @cd1 = ContentData::ContentData.new
+      NUMBER_INSTANCES.times do |i|
+        @cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
+      end
+      @cd2 = ContentData::ContentData.new(@cd1)
+      @cd2.add_instance((MAX_CHECKSUM+1).to_s, INSTANCE_SIZE, SERVER, PATH + "new", MTIME)
+    end
+
+
+    pending 'should consume acceptable amount of memory' do
+      puts "Memory usage test"
+      LIMIT_MEMORY = 100*1024
+
+      minus_thread = Thread.new { res_cd = ContentData.remove(@cd1, @cd2) }
+
+      memory_of_process = 0
+      memory_usage_thread = Thread.new do
+        while (memory_of_process < LIMIT_MEMORY && minus_thread.alive?)
+          memory_of_process = if Gem::win_platform?
+                                `tasklist /FI \"PID eq #{Process.pid}\" /NH /FO \"CSV\"`.split(',')[4]
+                              else
+                                `ps -o rss= -p #{Process.pid}`.to_i / 1000
+                              end
+          puts Process.pid + " => " + memory_of_process
+          sleep 1
+        end
+        if (minus_thread.alive?)
+          Thread.kill(minus_thread)
+        end
+      end
+
+      is_succeeded = memory_of_process
+      msg = "ContentData minus for #{NUMBER_INSTANCES} " +
+        (is_succeeded ? "" : "do not ") + "consume #{memory_of_process} bytes"
+
+      # main check
+      #timer.should be < LIMIT_TIME, msg
+      is_succeeded.should be_true
+      puts msg if is_succeeded
+
+      # checks that test was correct
+      if is_succeeded
+        res_cd.should be
+        res_cd.instances_size.should == 1
+      end
+    end
+
+    it 'should finish in acceptable time' do
+      LIMIT_TIME = 10*60;  # 10 minutes
+
+      res_cd = nil
+      minus_thread = Thread.new { res_cd = ContentData.remove(@cd1, @cd2) }
+
+      timer = 0
+      timer_thread = Thread.new do
+        while (timer < LIMIT_TIME && minus_thread.alive?)
+          timer += 1
+          sleep 1
+        end
+        if (minus_thread.alive?)
+          Thread.kill(minus_thread)
+        end
+      end
+      [minus_thread, timer_thread].each { |th| th.join }
+
+      is_succeeded = timer < LIMIT_TIME
+      msg = "ContentData minus for #{NUMBER_INSTANCES} " +
+        (is_succeeded ? "" : "do not ") + "finished in #{timer} seconds"
+
+      # main check
+      #timer.should be < LIMIT_TIME, msg
+      is_succeeded.should be_true
+      puts msg if is_succeeded
+
+      # checks that test was correct
+      if is_succeeded
+        res_cd.should be
+        res_cd.instances_size.should == 1
+      end
+    end
+  end
+end

--- a/spec/content_data/content_data_performance_spec.rb
+++ b/spec/content_data/content_data_performance_spec.rb
@@ -162,9 +162,9 @@ describe 'Content Data Performance Test' do
       NUMBER_INSTANCES.times do |i|
         @cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
       end
-      @cd1 = ContentData::ContentData.new
+      @cd2 = ContentData::ContentData.new
       NUMBER_INSTANCES.times do |i|
-        @cd1.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
+        @cd2.add_instance(i.to_s, INSTANCE_SIZE, SERVER, PATH + i.to_s, MTIME)
       end
       @cd2.add_instance((MAX_CHECKSUM+1).to_s, INSTANCE_SIZE, SERVER, PATH + "new", MTIME)
     end

--- a/spec/content_server/file_streamer_spec.rb
+++ b/spec/content_server/file_streamer_spec.rb
@@ -15,7 +15,7 @@ Params['log_write_to_console'] = false
 Params['log_write_to_file'] = false
 Params['log_debug_level'] = 0
 Params['streaming_chunk_size'] = 5
-Params.init ARGV
+Params.init Array.new
 Params['log_write_to_file'] = false
 Params['log_write_to_console'] = false
 Params['enable_monitoring'] = false


### PR DESCRIPTION
connected to #260 

---

Tests ContentData specifications:
basic ContentData methods on 350_000 instances
- finish in less then within 5 minutes
- consume less then 250 MB

NOTE the results are not exact cause they do not run in a clean environment and influenced from
monitoring/testing code, but they give a good approximation
Supposition: monitoring code penalty is insignificant against time/memory usage of the tested code

---

Was found that ConntentData cloning is extremely expensive operation

> Init one object 350000 instances in less then 300 seconds: finished in **5** seconds
> Init one object clone of 350000 in less then 300 seconds: finished in **59** seconds
> Init more then one object two object of 350000 instances each in less then 600 seconds: finished in 9 seconds
> Init more then one object three object of 350000 instances each in less then 900 seconds: finished in 15 seconds
> Init more then one object three object of 350000 instances each in less then 900 seconds: finished in 15 seconds

then minus of two ContentData objects was re-written without using cloning 

---

Was found that performance of Ruby2.1.1 is much better than Ruby1.9.3

> $ rvm current
> **ruby-1.9.3-p327**
> $ rspec -fd spec/content_data/content_data_performance_spec.rb
> .....
> minus of two objects with 350000 instances each finish in less then 300 seconds: **do not finished in 300 seconds**
> 
> $ rvm current
> ruby-2.1.1
> $ rspec -fd spec/content_data/content_data_performance_spec.rb
> ......
> minus of two objects with 350000 instances each finish in less then 300 seconds: **finished in 25 seconds**

**Then it is highly recommended to move to Ruby2.1.1**
With Ruby1.9.3 we still remain above 10 minutes for minus operation
