### PR TITLE
fix issue268

### DIFF
--- a/bin/fix_content_data
+++ b/bin/fix_content_data
@@ -1,11 +1,31 @@
 #!/usr/bin/env ruby
 
-# Get two file names, one is source content data other is destinations.
-# Converts source content data old format to new format and writes it to
-# destination file.
-
 require 'content_data/content_data'
+require 'params'
+
+usage = <<END
+Get two file names, one is source content data, other is destination,
+and a delimiter that separates fields in the source content data file
+(optional, default is ',').
+Converts source content data old format to new format and writes it
+to the destination file.
+Usage:
+#{$PROGRAM_NAME} old.cd fixed.cd
+is equivalent to
+#{$PROGRAM_NAME} old.cd fixed.cd ','
+END
+
+unless ARGV.length >= 2
+  puts usage
+  exit
+end
+
+Params.init
 
 cd = ContentData::ContentData.new
-cd.from_file_old(ARGV[0])
+if ARGV.length > 2
+  cd.from_file_old(ARGV[0], ARGV[2])
+else
+  cd.from_file_old(ARGV[0])
+end
 cd.to_file(ARGV[1])

--- a/lib/params.rb
+++ b/lib/params.rb
@@ -251,15 +251,21 @@ module Params
 
   # Initializes the project parameters.
   # Precedence is: Defined params, file and command line is highest.
-  def Params.init(args)
+  # If no args provided then only default values used.
+  def Params.init(args=nil)
     #define default configuration file
     Params['conf_file'] = "~/.bbfs/etc/config_#{File.basename($PROGRAM_NAME)}.yml"
 
     @init_info_messages = []
     @init_warning_messages = []
 
-    #parse command line argument and set configuration file if provided by user
-    results = parse_command_line_arguments(args)
+    results = Hash.new  # Hash to store parsing results.
+    options = Hash.new  # Hash of parsing options from Params.
+
+    # Parse command line argument and set configuration file if provided by user.
+    unless (args.nil?)
+      results = parse_command_line_arguments(args)
+    end
     if results['conf_file']
       Params['conf_file'] = File.expand_path(results['conf_file'])
       if !File.exist?(Params['conf_file']) or File.directory?(Params['conf_file'])
@@ -320,9 +326,6 @@ module Params
 
   #  Parse command line arguments
   def Params.parse_command_line_arguments(args)
-    results = Hash.new  # Hash to store parsing results.
-    options = Hash.new  # Hash of parsing options from Params.
-
     # Define options switch for parsing
     # Define List of options see example on
     # http://ruby.about.com/od/advancedruby/a/optionparser2.htm


### PR DESCRIPTION
Fix for #268 

1.No Params.init run while Log suppose that Params were initialized.
Solution: fixed in fix_content_data
2.There is no check of an instance line that was read from old-format file.
Solution: check was added
3.We suppose that delimiter in the old format files is a comma, but actually, in this specific case '<' was used as a delimiter.
Solution: additional parameter, that contains fields delimiter was added to fix_content_data executable and appropriate methods of ContentData. Default value was set to comma.
4. Params.init no more demands from user an input.
Motivation: there are a number of executables and tests that use Params.init but have no ARGV array.
5. command line help was added for bin/fix_content_data
